### PR TITLE
Timeout handling for call requests

### DIFF
--- a/UE/Application/Application.cpp
+++ b/UE/Application/Application.cpp
@@ -39,6 +39,7 @@ void Application::handleSib(common::BtsId btsId)
 void Application::handleAttachAccept()
 {
     context.state->handleAttachAccept();
+    context.state->handleCallRequest(common::PhoneNumber{1});
 }
 
 void Application::handleAttachReject()
@@ -51,14 +52,14 @@ void Application::handleCallRequest(common::PhoneNumber fromPhoneNumber)
     context.state->handleCallRequest(fromPhoneNumber);
 }
 
-void Application::handleCallRequestAccept(common::PhoneNumber fromPhoneNumber)
+void Application::handleCallRequestAccept()
 {
-    context.state->handleCallRequestAccept(fromPhoneNumber);
+    context.state->handleCallRequestAccept();
 }
 
-void Application::handleCallRequestReject(common::PhoneNumber fromPhoneNumber)
+void Application::handleCallRequestReject()
 {
-    context.state->handleCallRequestReject(fromPhoneNumber);
+    context.state->handleCallRequestReject();
 }
 
 }

--- a/UE/Application/Application.hpp
+++ b/UE/Application/Application.hpp
@@ -30,8 +30,8 @@ public:
     void handleAttachAccept() override;
     void handleAttachReject() override;
     void handleCallRequest(common::PhoneNumber fromPhoneNumber) override;
-    void handleCallRequestAccept(common::PhoneNumber fromPhoneNumber) override;
-    void handleCallRequestReject(common::PhoneNumber fromPhoneNumber) override;
+    void handleCallRequestAccept() override;
+    void handleCallRequestReject() override;
 
 private:
     Context context;

--- a/UE/Application/Context.hpp
+++ b/UE/Application/Context.hpp
@@ -14,6 +14,7 @@ struct Context
     IUserPort& user;
     ITimerPort& timer;
     std::unique_ptr<IEventsHandler> state{};
+    common::PhoneNumber foreignPhoneNumber{};
 
     template <typename State, typename ...Arg>
     void setState(Arg&& ...arg)

--- a/UE/Application/Context.hpp
+++ b/UE/Application/Context.hpp
@@ -14,7 +14,7 @@ struct Context
     IUserPort& user;
     ITimerPort& timer;
     std::unique_ptr<IEventsHandler> state{};
-    common::PhoneNumber foreignPhoneNumber{};
+    common::PhoneNumber callingPhoneNumber{};
 
     template <typename State, typename ...Arg>
     void setState(Arg&& ...arg)

--- a/UE/Application/Ports/BtsPort.cpp
+++ b/UE/Application/Ports/BtsPort.cpp
@@ -84,7 +84,7 @@ void BtsPort::sendAttachRequest(common::BtsId btsId)
 
 void BtsPort::sendCallAccept(common::PhoneNumber toPhoneNumber)
 {
-    logger.logInfo("BtsPort::sendCallAccept", to_string(toPhoneNumber));
+    logger.logInfo("BtsPort::sendCallAccept: ", to_string(toPhoneNumber));
     common::OutgoingMessage msg{common::MessageId::CallAccepted,
                                 phoneNumber,
                                 toPhoneNumber};

--- a/UE/Application/Ports/ITimerPort.hpp
+++ b/UE/Application/Ports/ITimerPort.hpp
@@ -2,6 +2,8 @@
 
 #include <chrono>
 
+#include "Messages/PhoneNumber.hpp"
+
 namespace ue
 {
 

--- a/UE/Application/Ports/IUserPort.hpp
+++ b/UE/Application/Ports/IUserPort.hpp
@@ -12,8 +12,8 @@ class IUserEventsHandler
 public:
     virtual ~IUserEventsHandler() = default;
 
-    virtual void handleCallRequestAccept(common::PhoneNumber fromPhoneNumber) = 0;
-    virtual void handleCallRequestReject(common::PhoneNumber fromPhoneNumber) = 0;
+    virtual void handleCallRequestAccept() = 0;
+    virtual void handleCallRequestReject() = 0;
 };
 
 class IUserPort

--- a/UE/Application/Ports/UserPort.hpp
+++ b/UE/Application/Ports/UserPort.hpp
@@ -27,6 +27,7 @@ private:
     common::PrefixedLogger logger;
     IUeGui& gui;
     common::PhoneNumber phoneNumber;
+    common::PhoneNumber foreignPhoneNumber;
     IUserEventsHandler* handler = nullptr;
 };
 

--- a/UE/Application/States/BaseState.cpp
+++ b/UE/Application/States/BaseState.cpp
@@ -45,12 +45,12 @@ void BaseState::handleCallRequest(common::PhoneNumber)
     logger.logError("Unexpected: handleCallRequest");
 }
 
-void BaseState::handleCallRequestAccept(common::PhoneNumber)
+void BaseState::handleCallRequestAccept()
 {
     logger.logError("Unexpected: handleCallRequestAcept");
 }
 
-void BaseState::handleCallRequestReject(common::PhoneNumber)
+void BaseState::handleCallRequestReject()
 {
     logger.logError("Unexpected: handleCallRequestReject");
 }

--- a/UE/Application/States/BaseState.hpp
+++ b/UE/Application/States/BaseState.hpp
@@ -22,8 +22,8 @@ public:
     void handleAttachAccept() override;
     void handleAttachReject() override;
     void handleCallRequest(common::PhoneNumber) override;
-    void handleCallRequestAccept(common::PhoneNumber fromPhoneNumber) override;
-    void handleCallRequestReject(common::PhoneNumber fromPhoneNumber) override;
+    void handleCallRequestAccept() override;
+    void handleCallRequestReject() override;
 
 protected:
     Context& context;

--- a/UE/Application/States/ConnectedState.cpp
+++ b/UE/Application/States/ConnectedState.cpp
@@ -16,6 +16,14 @@ void ConnectedState::handleDisconnected()
     context.setState<NotConnectedState>();
 }
 
+void ConnectedState::handleTimeout()
+{
+    logger.logInfo("ConnectedState::handleTimeout");
+    context.user.resetButtons();
+    context.user.showConnected();
+    context.bts.sendCallReject(context.foreignPhoneNumber);
+}
+
 void ConnectedState::handleCallRequest(common::PhoneNumber fromPhoneNumber)
 {
     logger.logInfo("ConnectedState::handleCallRequest");
@@ -31,6 +39,7 @@ void ConnectedState::handleCallRequest(common::PhoneNumber fromPhoneNumber)
     };
     context.user.setupIncomingCallButtons(acceptButtonCallback, rejectButtonCallback);
 
+    context.foreignPhoneNumber = fromPhoneNumber;
     using namespace std::chrono_literals;
     context.timer.startTimer(30s);
 }

--- a/UE/Application/States/ConnectedState.cpp
+++ b/UE/Application/States/ConnectedState.cpp
@@ -21,44 +21,46 @@ void ConnectedState::handleTimeout()
     logger.logInfo("ConnectedState::handleTimeout");
     context.user.resetButtons();
     context.user.showConnected();
-    context.bts.sendCallReject(context.foreignPhoneNumber);
+    context.bts.sendCallReject(context.callingPhoneNumber);
+    context.callingPhoneNumber.value = 0;
 }
 
 void ConnectedState::handleCallRequest(common::PhoneNumber fromPhoneNumber)
 {
     logger.logInfo("ConnectedState::handleCallRequest");
-    context.user.showCallRequest(fromPhoneNumber);
+    context.callingPhoneNumber = fromPhoneNumber;
 
-    auto acceptButtonCallback = [this, fromPhoneNumber]() {
+    context.user.showCallRequest(context.callingPhoneNumber);
+    auto acceptButtonCallback = [this]() {
         logger.logInfo("handleCallRequestAccept()");
-        handleCallRequestAccept(fromPhoneNumber);
+        handleCallRequestAccept();
     };
-    auto rejectButtonCallback = [this, fromPhoneNumber]() {
+    auto rejectButtonCallback = [this]() {
         logger.logInfo("handleCallRequestReject()");
-        handleCallRequestReject(fromPhoneNumber);
+        handleCallRequestReject();
     };
     context.user.setupIncomingCallButtons(acceptButtonCallback, rejectButtonCallback);
 
-    context.foreignPhoneNumber = fromPhoneNumber;
     using namespace std::chrono_literals;
     context.timer.startTimer(30s);
 }
 
-void ConnectedState::handleCallRequestAccept(common::PhoneNumber fromPhoneNumber)
+void ConnectedState::handleCallRequestAccept()
 {
     logger.logInfo("ConnectedState::handleCallRequestAccept");
     context.timer.stopTimer();
     context.user.resetButtons();
-    context.setState<TalkingState>(fromPhoneNumber);
+    context.setState<TalkingState>(context.callingPhoneNumber);
 }
 
-void ConnectedState::handleCallRequestReject(common::PhoneNumber fromPhoneNumber)
+void ConnectedState::handleCallRequestReject()
 {
     logger.logInfo("ConnectedState::handleCalLRequestReject");
     context.timer.stopTimer();
     context.user.resetButtons();
     context.user.showConnected();
-    context.bts.sendCallReject(fromPhoneNumber);
+    context.bts.sendCallReject(context.callingPhoneNumber);
+    context.callingPhoneNumber.value = 0;
 }
 
 }

--- a/UE/Application/States/ConnectedState.hpp
+++ b/UE/Application/States/ConnectedState.hpp
@@ -13,6 +13,7 @@ public:
     // IBtsEventsHandler interface
 public:
     void handleDisconnected() final;
+    void handleTimeout() final;
     void handleCallRequest(common::PhoneNumber) final;
     void handleCallRequestAccept(common::PhoneNumber fromPhoneNumber) final;
     void handleCallRequestReject(common::PhoneNumber fromPhoneNumber) final;

--- a/UE/Application/States/ConnectedState.hpp
+++ b/UE/Application/States/ConnectedState.hpp
@@ -15,8 +15,8 @@ public:
     void handleDisconnected() final;
     void handleTimeout() final;
     void handleCallRequest(common::PhoneNumber) final;
-    void handleCallRequestAccept(common::PhoneNumber fromPhoneNumber) final;
-    void handleCallRequestReject(common::PhoneNumber fromPhoneNumber) final;
+    void handleCallRequestAccept() final;
+    void handleCallRequestReject() final;
 };
 
 }

--- a/UE/Tests/Application/ApplicationTestSuite.cpp
+++ b/UE/Tests/Application/ApplicationTestSuite.cpp
@@ -119,13 +119,13 @@ TEST_F(ApplicationConnectedTestSuite, shallShowIncomingCallOnCallRequest)
     objectUnderTest.handleCallRequest(PHONE_NUMBER);
 }
 
-TEST_F(ApplicationConnectedTestSuite, shallRejectCallonCallRequestReject)
+TEST_F(ApplicationConnectedTestSuite, shallRejectCallOnCallRequestReject)
 {
     EXPECT_CALL(timerPortMock, stopTimer());
     EXPECT_CALL(userPortMock, resetButtons());
     EXPECT_CALL(userPortMock, showConnected());
     EXPECT_CALL(btsPortMock, sendCallReject(_));
-    objectUnderTest.handleCallRequestReject(PHONE_NUMBER);
+    objectUnderTest.handleCallRequestReject();
 }
 
 TEST_F(ApplicationConnectedTestSuite, shallRejectCallOnCallRequestTimeout)
@@ -153,7 +153,7 @@ void ApplicationTalkingTestSuite::doTalking()
     EXPECT_CALL(userPortMock, resetButtons());
     EXPECT_CALL(userPortMock, showTalking());
     EXPECT_CALL(btsPortMock, sendCallAccept(_));
-    objectUnderTest.handleCallRequestAccept(PHONE_NUMBER);
+    objectUnderTest.handleCallRequestAccept();
 }
 
 TEST_F(ApplicationTalkingTestSuite, shallAcceptIncomingCallOnAcceptButtonPress)

--- a/UE/Tests/Application/ApplicationTestSuite.cpp
+++ b/UE/Tests/Application/ApplicationTestSuite.cpp
@@ -128,6 +128,14 @@ TEST_F(ApplicationConnectedTestSuite, shallRejectCallonCallRequestReject)
     objectUnderTest.handleCallRequestReject(PHONE_NUMBER);
 }
 
+TEST_F(ApplicationConnectedTestSuite, shallRejectCallOnCallRequestTimeout)
+{
+    EXPECT_CALL(userPortMock, resetButtons());
+    EXPECT_CALL(userPortMock, showConnected());
+    EXPECT_CALL(btsPortMock, sendCallReject(_));
+    objectUnderTest.handleTimeout();
+}
+
 struct ApplicationTalkingTestSuite : ApplicationConnectedTestSuite
 {
     ApplicationTalkingTestSuite();

--- a/UE/Tests/Application/Mocks/IUserPortMock.hpp
+++ b/UE/Tests/Application/Mocks/IUserPortMock.hpp
@@ -12,8 +12,8 @@ public:
     IUserEventsHandlerMock();
     ~IUserEventsHandlerMock() override;
 
-    MOCK_METHOD(void, handleCallRequestAccept, (common::PhoneNumber), (final));
-    MOCK_METHOD(void, handleCallRequestReject, (common::PhoneNumber), (final));
+    MOCK_METHOD(void, handleCallRequestAccept, (), (final));
+    MOCK_METHOD(void, handleCallRequestReject, (), (final));
 };
 
 class IUserPortMock : public IUserPort


### PR DESCRIPTION
Added handling timeout for Call Request. However, in order to implement `handleTimeout()` and have access to the _fromPhoneNumber_ (the phone number from which the request came) I had to add it to the Context, which might not be ideal. I tried to modify the `ITimerEventsHandler` but couldn't get it to work, maybe I am missing something.
Long story short - I would like your opinion on that solution.