### PR TITLE
Sending call request alternative failure scenario - timeout

### DIFF
--- a/UE/Application/Application.cpp
+++ b/UE/Application/Application.cpp
@@ -56,9 +56,9 @@ void Application::handleCallAccepted()
     context.state->handleCallAccepted();
 }
 
-void Application::handleCallFailure(std::string message)
+void Application::handleCallFailure(std::string &&message)
 {
-    context.state->handleCallFailure(message);
+    context.state->handleCallFailure(std::move(message));
 }
 
 }

--- a/UE/Application/Application.hpp
+++ b/UE/Application/Application.hpp
@@ -30,7 +30,7 @@ public:
     void handleAttachAccept() override;
     void handleAttachReject() override;
     void handleCallAccepted() override;
-    void handleCallFailure(std::string) override;
+    void handleCallFailure(std::string &&) override;
 
     // IUserEventsHandler interface
     void handleSendCallRequest(common::PhoneNumber to) override;

--- a/UE/Application/Ports/IBtsPort.hpp
+++ b/UE/Application/Ports/IBtsPort.hpp
@@ -16,7 +16,7 @@ public:
     virtual void handleAttachAccept() = 0;
     virtual void handleAttachReject() = 0;
     virtual void handleCallAccepted() = 0;
-    virtual void handleCallFailure(std::string) = 0;
+    virtual void handleCallFailure(std::string &&) = 0;
 };
 
 class IBtsPort

--- a/UE/Application/Ports/IUserPort.hpp
+++ b/UE/Application/Ports/IUserPort.hpp
@@ -22,7 +22,7 @@ public:
     virtual void showConnecting() = 0;
     virtual void showConnected() = 0;
     virtual void setupCallReceiver() = 0;
-    virtual void showShortInfo(std::string) = 0;
+    virtual void showShortInfo(std::string &&) = 0;
 };
 
 }

--- a/UE/Application/Ports/TimerPort.cpp
+++ b/UE/Application/Ports/TimerPort.cpp
@@ -39,7 +39,7 @@ void TimerPort::timerThread(Duration duration)
     for(int i = duration / 100ms; i > -1; i--)
     {
         std::this_thread::sleep_for(100ms);
-        if (!this->running)
+        if (not running)
             return;
     }
     logger.logError("Timeout");

--- a/UE/Application/Ports/TimerPort.cpp
+++ b/UE/Application/Ports/TimerPort.cpp
@@ -29,8 +29,8 @@ void TimerPort::startTimer(Duration duration)
 void TimerPort::stopTimer()
 {
     logger.logDebug("Stop timer");
-    this->running = false;
-    this->timer.get();
+    running = false;
+    timer.get();
 }
 
 void TimerPort::timerThread(Duration duration)

--- a/UE/Application/Ports/TimerPort.cpp
+++ b/UE/Application/Ports/TimerPort.cpp
@@ -22,11 +22,28 @@ void TimerPort::stop()
 void TimerPort::startTimer(Duration duration)
 {
     logger.logDebug("Start timer: ", duration.count(), "ms");
+    this->running = true;
+    this->timer = std::async(&TimerPort::timerThread, this, duration);
 }
 
 void TimerPort::stopTimer()
 {
     logger.logDebug("Stop timer");
+    this->running = false;
+    this->timer.get();
+}
+
+void TimerPort::timerThread(Duration duration)
+{
+    using namespace std::chrono_literals;
+    for(int i = duration / 100ms; i > -1; i--)
+    {
+        std::this_thread::sleep_for(100ms);
+        if (!this->running)
+            return;
+    }
+    logger.logError("Timeout");
+    handler->handleTimeout();
 }
 
 }

--- a/UE/Application/Ports/TimerPort.cpp
+++ b/UE/Application/Ports/TimerPort.cpp
@@ -22,8 +22,8 @@ void TimerPort::stop()
 void TimerPort::startTimer(Duration duration)
 {
     logger.logDebug("Start timer: ", duration.count(), "ms");
-    this->running = true;
-    this->timer = std::async(&TimerPort::timerThread, this, duration);
+    running = true;
+    timer = std::async(&TimerPort::timerThread, this, duration);
 }
 
 void TimerPort::stopTimer()

--- a/UE/Application/Ports/TimerPort.cpp
+++ b/UE/Application/Ports/TimerPort.cpp
@@ -36,13 +36,13 @@ void TimerPort::stopTimer()
 void TimerPort::timerThread(Duration duration)
 {
     using namespace std::chrono_literals;
-    for(int i = duration / 100ms; i > -1; i--)
+    for(int i = duration / 100ms; i >= 0; i--)
     {
         std::this_thread::sleep_for(100ms);
         if (not running)
             return;
     }
-    logger.logError("Timeout");
+    logger.logInfo("Timeout");
     handler->handleTimeout();
 }
 

--- a/UE/Application/Ports/TimerPort.hpp
+++ b/UE/Application/Ports/TimerPort.hpp
@@ -2,6 +2,7 @@
 
 #include "ITimerPort.hpp"
 #include "Logger/PrefixedLogger.hpp"
+#include <future>
 
 namespace ue
 {
@@ -19,6 +20,9 @@ public:
     void stopTimer() override;
 
 private:
+    void timerThread(Duration duration);
+    bool running;
+    std::future<void> timer;
     common::PrefixedLogger logger;
     ITimerEventsHandler* handler = nullptr;
 };

--- a/UE/Application/Ports/UserPort.cpp
+++ b/UE/Application/Ports/UserPort.cpp
@@ -59,7 +59,7 @@ void UserPort::setupCallReceiver()
     });
 }
 
-void UserPort::showShortInfo(std::string message)
+void UserPort::showShortInfo(std::string &&message)
 {
     // TODO Add timeout hiding message after few second even where the button is not pressed.
     logger.logDebug("showShortInfo - message:", message);

--- a/UE/Application/Ports/UserPort.cpp
+++ b/UE/Application/Ports/UserPort.cpp
@@ -61,6 +61,7 @@ void UserPort::setupCallReceiver()
 
 void UserPort::showShortInfo(std::string message)
 {
+    // TODO Add timeout hiding message after few second even where the button is not pressed.
     logger.logDebug("showShortInfo - message:", message);
     auto& mode = gui.setAlertMode();
     mode.setText(message);

--- a/UE/Application/Ports/UserPort.cpp
+++ b/UE/Application/Ports/UserPort.cpp
@@ -54,6 +54,7 @@ void UserPort::setupCallReceiver()
     auto& mode = gui.setDialMode();
     gui.setAcceptCallback([&](){
         logger.logInfo("to: ", mode.getPhoneNumber());
+        showShortInfo("Calling...");
         this->handler->handleSendCallRequest(mode.getPhoneNumber());
     });
 }

--- a/UE/Application/Ports/UserPort.hpp
+++ b/UE/Application/Ports/UserPort.hpp
@@ -19,7 +19,7 @@ public:
     void showConnecting() override;
     void showConnected() override;
     void setupCallReceiver() override;
-    void showShortInfo(std::string) override;
+    void showShortInfo(std::string &&) override;
 
 private:
     common::PrefixedLogger logger;

--- a/UE/Application/States/BaseState.cpp
+++ b/UE/Application/States/BaseState.cpp
@@ -50,7 +50,7 @@ void BaseState::handleCallAccepted()
     logger.logError("Unexpected: handleCallAccepted");
 }
 
-void BaseState::handleCallFailure(std::string)
+void BaseState::handleCallFailure(std::string &&)
 {
     logger.logError("Unexpected: handleCallFailure");
 }

--- a/UE/Application/States/BaseState.hpp
+++ b/UE/Application/States/BaseState.hpp
@@ -22,7 +22,7 @@ public:
     void handleAttachAccept() override;
     void handleAttachReject() override;
     void handleCallAccepted() override;
-    void handleCallFailure(std::string) override;
+    void handleCallFailure(std::string &&) override;
 
     // IUserEventsHandler interface
     void handleSendCallRequest(common::PhoneNumber) override;

--- a/UE/Application/States/ConnectedState.cpp
+++ b/UE/Application/States/ConnectedState.cpp
@@ -18,18 +18,28 @@ void ConnectedState::handleDisconnected()
 void ConnectedState::handleSendCallRequest(common::PhoneNumber to)
 {
     context.bts.sendCallRequest(to);
+    using namespace std::chrono_literals;
+    context.timer.startTimer(60s);
 }
 
 void ConnectedState::handleCallAccepted()
 {
     // TODO change mode to talking state
     logger.logInfo("ConnectedState: handleCallAccepted");
+    context.timer.stopTimer();
 }
 
 void ConnectedState::handleCallDropped()
 {
     logger.logInfo("ConnectedState: handleCallDropped");
     context.user.showShortInfo("User dropped a call.");
+    context.timer.stopTimer();
+}
+
+void ConnectedState::handleTimeout()
+{
+    logger.logInfo("Timeout");
+    context.user.showShortInfo("Timeout.");
 }
 
 }

--- a/UE/Application/States/ConnectedState.cpp
+++ b/UE/Application/States/ConnectedState.cpp
@@ -29,10 +29,10 @@ void ConnectedState::handleCallAccepted()
     context.timer.stopTimer();
 }
 
-void ConnectedState::handleCallFailure(std::string message)
+void ConnectedState::handleCallFailure(std::string &&message)
 {
     logger.logInfo("ConnectedState: handleCallFailure");
-    context.user.showShortInfo(message);
+    context.user.showShortInfo(std::move(message));
     context.timer.stopTimer();
 }
 

--- a/UE/Application/States/ConnectedState.cpp
+++ b/UE/Application/States/ConnectedState.cpp
@@ -18,18 +18,28 @@ void ConnectedState::handleDisconnected()
 void ConnectedState::handleSendCallRequest(common::PhoneNumber to)
 {
     context.bts.sendCallRequest(to);
+    using namespace std::chrono_literals;
+    context.timer.startTimer(60s);
 }
 
 void ConnectedState::handleCallAccepted()
 {
     // TODO change mode to talking state
     logger.logInfo("ConnectedState: handleCallAccepted");
+    context.timer.stopTimer();
 }
 
 void ConnectedState::handleCallFailure(std::string message)
 {
     logger.logInfo("ConnectedState: handleCallFailure");
     context.user.showShortInfo(message);
+    context.timer.stopTimer();
+}
+
+    void ConnectedState::handleTimeout()
+    {
+        logger.logInfo("Timeout");
+        context.user.showShortInfo("Timeout.");
 }
 
 }

--- a/UE/Application/States/ConnectedState.cpp
+++ b/UE/Application/States/ConnectedState.cpp
@@ -40,7 +40,6 @@ void ConnectedState::handleTimeout()
 {
     logger.logInfo("Timeout");
     context.user.showShortInfo("Timeout.");
-    context.timer.stopTimer();
 }
 
 }

--- a/UE/Application/States/ConnectedState.cpp
+++ b/UE/Application/States/ConnectedState.cpp
@@ -32,7 +32,7 @@ void ConnectedState::handleCallAccepted()
 void ConnectedState::handleCallFailure(std::string message)
 {
     logger.logInfo("ConnectedState: handleCallFailure");
-    context.user.showShortInfo(message);
+    context.user.showShortInfo((std::basic_string<char>) message);
     context.timer.stopTimer();
 }
 

--- a/UE/Application/States/ConnectedState.hpp
+++ b/UE/Application/States/ConnectedState.hpp
@@ -10,6 +10,10 @@ class ConnectedState : public BaseState
 public:
     ConnectedState(Context& context);
 
+    // ITimerEventsHandler interface
+public:
+    void handleTimeout() final;
+
     // IBtsEventsHandler interface
 public:
     void handleDisconnected() final;

--- a/UE/Application/States/ConnectedState.hpp
+++ b/UE/Application/States/ConnectedState.hpp
@@ -18,7 +18,7 @@ public:
 public:
     void handleDisconnected() final;
     void handleCallAccepted() final;
-    void handleCallFailure(std::string) final;
+    void handleCallFailure(std::string &&) final;
 
     // IUserEventsHandler interface
     void handleSendCallRequest(common::PhoneNumber to) final;


### PR DESCRIPTION
I added the next failure substory - Timeout, which is completed and I also implemented a timeout thread in `TimerPort` which was not implemented. So far as we used in our code a `startTimer()` method - nothing happened. Now after duration time `handler->handleTimeout()` is calling.
https://github.com/Koci0/Nokia-PK-2021/blob/55eeeaada26f14b3ae0c44c4c103441d9a1988b5/UE/Application/Ports/TimerPort.cpp#L36-L47
If you have an idea of how to code it better, please let me know.