### PR TITLE
Add static checks

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,6 +1,6 @@
 name: C/C++ CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,6 +1,6 @@
 name: C/C++ CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,6 +1,6 @@
 name: C/C++ CI
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -13,8 +13,11 @@ jobs:
       uses: jurplel/install-qt-action@v2
     - name: cmake
       run: cmake .
-    - name: make all targets
-      run: make all
+    - name: Make all targets
+      run: make all 2> >(tee make.log)
+
+    - name: Extract errors for Application
+      run: cat make.log | grep "UE/Application" -A 2 | grep -v COMMON | grep -v "\-\-" | grep "|" --context 2
 
     - name: UT for BtsApplication
       run: make BtsApplicationUT 

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -13,5 +13,6 @@ jobs:
       run: sudo apt install cppcheck
 
     - name: Run cppcheck
-      run: cppcheck --enable=all --inconclusive --std=c++17 UE/Application
-
+      run: |
+              cppcheck --enable=all --inconclusive --std=c++17 UE/Application 2> >(tee cppcheck.log)
+              [ ! -s cppcheck.log ]

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,15 +1,17 @@
 name: Cppcheck
+
 on: [push]
 
 jobs:
   build:
-    name: cppcheck
+
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
-      - name: cppcheck
-        uses: deep5050/cppcheck-action@main
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN}}
-          exclude_check: ./BTS ./COMMON ./Doc ./googletest
-          std: c++17
+    - uses: actions/checkout@v2
+    - name: Install cppcheck
+      run: sudo apt install cppcheck
+
+    - name: Run cppcheck
+      run: cppcheck --enable=all --inconclusive --std=c++17 UE/Application
+

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,15 @@
+name: Cppcheck
+on: [push]
+
+jobs:
+  build:
+    name: cppcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: cppcheck
+        uses: deep5050/cppcheck-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN}}
+          exclude_check: ./BTS ./COMMON ./Doc ./googletest
+          std: c++17

--- a/UE/Application/CMakeLists.txt
+++ b/UE/Application/CMakeLists.txt
@@ -6,4 +6,6 @@ aux_source_directory(Ports SRC_LIST)
 aux_source_directory(States SRC_LIST)
 
 add_library(${PROJECT_NAME} ${SRC_LIST})
-target_link_libraries(${PROJECT_NAME} Common)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
+target_link_libraries(${PROJECT_NAME} PRIVATE Common)
+


### PR DESCRIPTION
Added flags for compiler (g++) and extracted the logs to reflect only "our" part (so basically excluded all files except `UE/Application`). It passes even with errors found, so we have to check the logs before merging.
Added new job to run `cppcheck` that failes when any error is detected.