### PR TITLE
now talking messages are cleared before new call

### DIFF
--- a/UE/Application/Ports/UserPort.cpp
+++ b/UE/Application/Ports/UserPort.cpp
@@ -77,7 +77,6 @@ void UserPort::setupCallReceiver()
 
 void UserPort::showShortInfo(std::string &&message, InternalMethod onRejectFunction)
 {
-    // TODO Add timeout hiding message after few second even where the button is not pressed.
     logger.logDebug("UserPort::showShortInfo:", message);
     auto& mode = gui.setAlertMode();
     mode.setText(std::move(message));
@@ -163,6 +162,8 @@ void UserPort::showTalking(std::string& text)
     auto& talking = gui.setCallMode();
     if(!text.empty()){
         talking.appendIncomingText(text);
+    } else {
+        talking.clearIncomingText();
     }
     gui.setAcceptCallback([&](){
         logger.logInfo("UserPort::Talking ", talking.getOutgoingText());

--- a/UE/Tests/Application/Ports/UserPortTestSuite.cpp
+++ b/UE/Tests/Application/Ports/UserPortTestSuite.cpp
@@ -103,6 +103,7 @@ TEST_F(UserPortTestSuite, shallShowCallModeOnTalking)
     EXPECT_CALL(guiMock,setCallMode()).WillOnce(ReturnRef(callModeMock));
     std::string empty = "";
     EXPECT_CALL(guiMock, setAcceptCallback(_));
+    EXPECT_CALL(callModeMock, clearIncomingText());
     objectUnderTest.showTalking(empty);
 }
 


### PR DESCRIPTION
I set up this newly implemented function, it doesn't work as we pleased (due to how UE::showTalking function works). So it need to be refactored in the future, but even in this form it should be pushed to our todays release IMO.